### PR TITLE
Add Kasun Vithanage as committer

### DIFF
--- a/docs/other/committers.md
+++ b/docs/other/committers.md
@@ -3,6 +3,7 @@
 - [Shalitha Suranga](https://github.com/shalithasuranga) - PMC
 - [Deepal Samarakoon](https://github.com/deepz123) - PMC
 - [Chathumaduri Hettiarachchi](https://github.com/Chathumaduri456) - PMC
+- [Kasun Vithanage](https://github.com/kasvith)
 
 See more contributors [here](https://github.com/neutralinojs/neutralinojs/graphs/contributors)
 


### PR DESCRIPTION
Relates to issue #83 - I assumed you wanted the link to go to the user's github page rather than his "kache" repo. Also I was unsure of his "PMC" status so I left it off.