### PR TITLE
fix typos in api and cli args

### DIFF
--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -5,18 +5,21 @@ title: Neutralino.filesystem
 `Neutralino.filesystem` namespace contains methods for handling files.
 
 ## filesystem.createDirectory(CreateDirectoryOptions)
+
 Creates a new directory.
 
 ### CreateDirectoryOptions
+
 - `path`: New directory path.
 
 ```js
 await Neutralino.filesystem.createDirectory({
-  path: './newDirectory',
+  path: "./newDirectory",
 });
 ```
 
 ## filesystem.removeDirectory(RemoveDirectoryOptions)
+
 Removes given directories.
 
 ### RemoveDirectoryOptions
@@ -25,43 +28,48 @@ Removes given directories.
 
 ```js
 await Neutralino.filesystem.removeDirectory({
-  path: './tmpDirectory',
+  path: "./tmpDirectory",
 });
 ```
 
 ## filesystem.writeFile(WriteFileOptions)
+
 Writes new text files with data.
 
 ### WriteFileOptions
+
 - `fileName`: File name.
 - `data`: Content of the file in string format.
 
 ```js
 await Neutralino.filesystem.writeFile({
-  fileName: './myFile.txt',
-  data: 'Sample content'
+  fileName: "./myFile.txt",
+  data: "Sample content",
 });
 ```
 
 ## filesystem.writeBinaryFile(WriteBinaryFileOptions)
+
 Writes new binary files with data.
 
 ### WriteBinaryFileOptions
+
 - `fileName`: File name.
-- `data`: Content of the binary file as an 
-[ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+- `data`: Content of the binary file as an
+  [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
 ```js
 let rawBin = new ArrayBuffer(1);
 let view = new Uint8Array(rawBin);
 view[0] = 64; // Saves ASCII '@' to the binary file
 await Neutralino.filesystem.writeBinaryFile({
-  fileName: './myFile.bin',
-  data: rawBin
+  fileName: "./myFile.bin",
+  data: rawBin,
 });
 ```
 
 ## filesystem.readFile(ReadFileOptions)
+
 Reads text files.
 
 ### ReadFileOptions
@@ -69,16 +77,18 @@ Reads text files.
 - `fileName`: File name.
 
 ### Return object (awaited):
+
 - `data`: File content.
 
 ```js
 let response = await Neutralino.filesystem.readFile({
-  fileName: './myFile.txt'
+  fileName: "./myFile.txt",
 });
 console.log(`Content: ${response.data}`);
 ```
 
 ## filesystem.readBinaryFile(ReadBinaryFileOptions)
+
 Reads binary files.
 
 ### ReadFileOptions
@@ -86,31 +96,34 @@ Reads binary files.
 - `fileName`: File name.
 
 ### Return object (awaited):
-- `data`: Content of the binary file as an 
-[ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+- `data`: Content of the binary file as an
+  [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
 ```js
 let response = await Neutralino.filesystem.readBinaryFile({
-  fileName: './myFile.bin'
+  fileName: "./myFile.bin",
 });
 let view = new Uint8Array(response.data);
-console.log('Binary content: ', view);
+console.log("Binary content: ", view);
 ```
 
 ## filesystem.removeFile(RemoveFileOptions)
+
 Removes given file.
 
 ### RemoveFileOptions
-- `fileName`: File name.
 
+- `fileName`: File name.
 
 ```js
 await Neutralino.filesystem.removeFile({
-  fileName: './myFile.txt'
+  fileName: "./myFile.txt",
 });
 ```
 
 ## filesystem.readDirectory(ReadFileOptions)
+
 Reads a whole directory.
 
 ### ReadDirectoryOptions
@@ -118,62 +131,68 @@ Reads a whole directory.
 - `path`: File name.
 
 ### Return object (awaited):
+
 - `entries`: An array of sub-directories and files.
-  * `entry`: file name.
-  * `type`: The type of the entry (`FILE` or `DIRECTORY`).
+  - `entry`: file name.
+  - `type`: The type of the entry (`FILE` or `DIRECTORY`).
 
 ```js
 let response = await Neutralino.filesystem.readDirectory({
-  path: NL_PATH
+  path: NL_PATH,
 });
-console.log('Content: ', response.entries);
+console.log("Content: ", response.entries);
 ```
 
 ## filesystem.copyFile(source, destination)
+
 Copies a file to a new destination.
 
 ### Parameters
 
 - `source`: Source file as a string.
-- `destination`: Destionation file as a string.
+- `destination`: Destination file as a string.
 
 ```js
 await Neutralino.filesystem.copyFile({
-  source: './source.txt',
-  destination: './destination.txt'
+  source: "./source.txt",
+  destination: "./destination.txt",
 });
 ```
 
 ## filesystem.moveFile(source, destination)
+
 Moves a file to a new destination.
 
 ### Parameters
 
 - `source`: Source file as a string.
-- `destination`: Destionation file as a string.
+- `destination`: Destination file as a string.
 
 ```js
 await Neutralino.filesystem.moveFile({
-  source: './source.txt',
-  destination: './destination.txt'
+  source: "./source.txt",
+  destination: "./destination.txt",
 });
 ```
 
 ## filesystem.getStats(path)
-Returns file statistics for the given path. If the given path doesn't exist or is unable to access, 
-the awaited method will throw an error. Therefore, you can use this method to check the existance of a file or directory.
+
+Returns file statistics for the given path. If the given path doesn't exist or is unable to access,
+the awaited method will throw an error. Therefore, you can use this method to check the existence of a file or directory.
 
 ### Parameters
 
 - `path`: File or directory path.
 
 ### Return object (awaited):
+
 - `size`: Size in bytes.
 - `isFile`: `true` if the path represents a normal file.
 - `isDirectory`: `true` if the path represents a directory.
 
 ```js
 let response = await Neutralino.filesystem.getStats({
-  path: './sampleVideo.mp4'
+  path: "./sampleVideo.mp4",
 });
-console.log('Stats:', response);
+console.log("Stats:", response);
+```

--- a/docs/cli/internal-cli-arguments.md
+++ b/docs/cli/internal-cli-arguments.md
@@ -96,7 +96,7 @@ Overrides the window's maximum height.
 Overrides the window's initial resizability status. 
 
 :::tip
-The right hand value is optinal for the for boolean type CLI arguments. Therefore, you can use `--window-full-screen` 
+The right hand value is optional for the for boolean type CLI arguments. Therefore, you can use `--window-full-screen` 
 instead of `--window-full-screen=true`. However, if you define `window.fullScreen` as `true` and you need to override it as 
 `false` you have to use `--window-full-screen=false`.
 :::


### PR DESCRIPTION
Fixed spelling of "destination" and "existence" in docs/api/filesystem
Fixed spelling of "optional" in docs/cli/internal