### PR TITLE
Incorrect API Sample Code Fixes

### DIFF
--- a/docs/api/init.md
+++ b/docs/api/init.md
@@ -17,7 +17,7 @@ native API function. The `init` function does the following tasks when it's call
 Neutralino.init();
 
 Neutralino.events.on('ready', () => {
-    Neutralino.os.showMessage('Welcome', 'Hello Neutralinojs');
+    Neutralino.os.showMessageBox('Welcome', 'Hello Neutralinojs');
 });
 ```
 


### PR DESCRIPTION
Changed `os.showMessage` to `os.showMessageBox` to match actual API in the `os` namespace. Confirmed this check on both the documentation:  https://neutralino.js.org/docs/api/os/#osshowmessageboxtitle-content-choice-icon and on the v3 specifications: https://github.com/neutralinojs/v2-client-specification#os-done