### PR TITLE
Fix: open function moved from 'app to 'os' namespace. Fix for docs.

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -60,18 +60,3 @@ and using `0` as the port.
 let config = await Neutralino.app.getConfig();
 console.log('URL = ', config.url);
 ```
-
-## app.open(url)
-Opens a URL with the default web browser. 
-
-:::tip
-If your application is running in the default web browser, this method will open a new tab.
-:::
-
-### Parameters
-
-- `url`: URL to be opened.
-
-```js
-await Neutralino.app.open('https://neutralino.js.org');
-```

--- a/docs/api/os.md
+++ b/docs/api/os.md
@@ -173,3 +173,18 @@ User action.
 let downloadsPath = await Neutralino.os.getPath('downloads');
 console.log(`Downloads folder: ${downloadsPath}`);
 ```
+
+## os.open(url)
+Opens a URL with the default web browser. 
+
+:::tip
+If your application is running in the default web browser, this method will open a new tab.
+:::
+
+### Parameters
+
+- `url`: URL to be opened.
+
+```js
+Neutralino.os.open('https://neutralino.js.org');
+```


### PR DESCRIPTION
The open function seems to have been moved to the `os` namespace. `Neutralino.app.open` is not a function anymore as far as I can tell.