### PR TITLE
docs: extension id characters

### DIFF
--- a/docs/how-to/extensions-overview.md
+++ b/docs/how-to/extensions-overview.md
@@ -29,7 +29,7 @@ First, you need to define extensions you use in `neutralinojs.config.json` with 
 ]
 ```
 
-- `id` String: A unique key to identify each extension.
+- `id` String: A unique key to identify each extension. This id cannot contain any characters except for letters, numbers, and periods.
 - `command` String (optional): A cross-platform command to start the extension. Eg: `node ${NL_PATH}/extensions/binary/main.js`
 will work on every platform.
 - `commandLinux` String (optional): Extension startup command for Linux.


### PR DESCRIPTION
Closes https://github.com/neutralinojs/neutralinojs/issues/801

Extension ID's cannot contain dashes or other special characters. If they do the websocket connection wont work.

It was really hard to figure this out (took me like 4 - 5 hours). I don't know C++ but I figured out how to compile neu, peppered debug logs everywhere, tried a bunch of different things, and eventually figured it out. Hopefully this note will save others in the future!