### PR TITLE
updated to the latest workflow, added command for arch linux

### DIFF
--- a/docs/contributing/framework-developer-guide.mdx
+++ b/docs/contributing/framework-developer-guide.mdx
@@ -12,7 +12,7 @@ Note that this guide is for contributors. If you are getting started with Neutra
 you can start from [here](../getting-started/your-first-neutralinojs-app.mdx).
 
 ## Setup and build the framework
-
+### Cloning the Repository
 First, clone the main repository.
 
 ```bash
@@ -20,6 +20,7 @@ git clone https://github.com/neutralinojs/neutralinojs.git
 cd neutralinojs
 ```
 
+### Installing Compilation tools and dependencies
 ### Linux
 
 No need for separate compilers because Linux distributions usually have GNU C/C++ compilers installed already.
@@ -32,8 +33,7 @@ Install GTK, WebKit, other libraries with the following command.
 sudo apt install \
     libgtk-3-dev \
     libwebkit2gtk-4.0-37 \
-    libwebkit2gtk-4.0-dev \
-    libayatana-appindicator3-dev
+    libwebkit2gtk-4.0-dev 
 ```
 
 **Fedora**
@@ -41,16 +41,17 @@ sudo apt install \
 ```bash
 sudo dnf install \
     @development-tools \
-    libappindicator-gtk3.x86_64 \
     gtk3 \
     webkit2gtk3.x86_64 \
     webkit2gtk3-devel.x86_64
 ```
 
-Compile the Neutralinojs framework.
+**Arch**
 
 ```bash
-bash build_linux.sh # [ia32, x64, armhf, arm64]
+sudo pacman -S \
+    gtk3 \
+    webkit2gtk
 ```
 
 ### Windows
@@ -58,21 +59,18 @@ bash build_linux.sh # [ia32, x64, armhf, arm64]
 Install the latest Visual Studio IDE. Neutralinojs compilation on Windows will use
 MSVC (aka `cl.exe`) C++ compiler.
 
-Compile the Neutralinojs framework.
-
-```bash
-./build_windows.bat # [ia32, x64]
-```
-
 ### macOS
 
 Install Xcode Command Line Tools.
 
-Compile the Neutralinojs framework.
+### Compile the Neutralinojs framework.
+
+Run the following script in order build the framework.
 
 ```bash
-bash build_macos.sh # [ia32, x64, armhf, arm64]
+python scripts/bz.py
 ```
+**Note:** You need to have [python](https://www.python.org/downloads/) installed to run this script.
 
 ## Setup and build the client
 

--- a/docs/contributing/framework-developer-guide.mdx
+++ b/docs/contributing/framework-developer-guide.mdx
@@ -12,7 +12,8 @@ Note that this guide is for contributors. If you are getting started with Neutra
 you can start from [here](../getting-started/your-first-neutralinojs-app.mdx).
 
 ## Setup and build the framework
-### Cloning the Repository
+
+### Cloning the repository
 First, clone the main repository.
 
 ```bash
@@ -20,7 +21,7 @@ git clone https://github.com/neutralinojs/neutralinojs.git
 cd neutralinojs
 ```
 
-### Installing Compilation tools and dependencies
+### Installing compilation tools and dependencies
 ### Linux
 
 No need for separate compilers because Linux distributions usually have GNU C/C++ compilers installed already.
@@ -70,7 +71,9 @@ Run the following script in order build the framework.
 ```bash
 python scripts/bz.py
 ```
-**Note:** You need to have [python](https://www.python.org/downloads/) installed to run this script.
+:::info
+You need to have the [Python](https://www.python.org/downloads/) interpreter (version 3.x) installed to run this script.
+:::
 
 ## Setup and build the client
 


### PR DESCRIPTION
1. Removed libayatana-appindicator from the command as it is no longer a hard dependency.
2. Added dependency install command for arch linux since the library names are a bit different.
3. Replaced the legacy build script installation with the buildZri python script.

I tried to edit the doc to represent the latest workflow.