### PR TITLE
Update `filesystem.getStats` return Object to include `createdAt` and `modifiedAt`

### DIFF
--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -183,7 +183,7 @@ Therefore, you can use this method to check for the existance of a file or direc
 - `size` Number: Size in bytes.
 - `isFile` Boolean: `true` if the path represents a normal file.
 - `isDirectory` Boolean: `true` if the path represents a directory.
-- `createdAt` Number: Unix time of the file creation in milliseconds (Note: The meaning of this values varies on different operating systems).
+- `createdAt` Number: Unix time of the file creation in milliseconds (Note: The meaning of this value varies on different operating systems).
 - `modifiedAt` Number: Unix time of the last file modification in milliseconds.
 
 ```js

--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -183,8 +183,8 @@ Therefore, you can use this method to check for the existance of a file or direc
 - `size` Number: Size in bytes.
 - `isFile` Boolean: `true` if the path represents a normal file.
 - `isDirectory` Boolean: `true` if the path represents a directory.
-- `createdAt` Number: Unix time of the file creation in milliseconds (Note: The meaning of this value varies on different operating systems).
-- `modifiedAt` Number: Unix time of the last file modification in milliseconds.
+- `createdAt` Number: On Windows, returns Unix milliseconds of the file creation time &mdash; On Unix or Unix-like platforms, returns Unix milliseconds of the last [inode](https://en.wikipedia.org/wiki/Inode) modification time.
+- `modifiedAt` Number: Unix milliseconds of the last file modification time.
 
 ```js
 let stats = await Neutralino.filesystem.getStats('./sampleVideo.mp4');

--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -183,6 +183,8 @@ Therefore, you can use this method to check for the existance of a file or direc
 - `size` Number: Size in bytes.
 - `isFile` Boolean: `true` if the path represents a normal file.
 - `isDirectory` Boolean: `true` if the path represents a directory.
+- `createdAt` Number: Unix time of the file creation in milliseconds (Note: The meaning of this values varies on different operating systems).
+- `modifiedAt` Number: Unix time of the last file modification in milliseconds.
 
 ```js
 let stats = await Neutralino.filesystem.getStats('./sampleVideo.mp4');


### PR DESCRIPTION
This change becomes vital, if the pull request [Update filesystem.getStats(path) to fetch last modified time](https://github.com/neutralinojs/neutralinojs/pull/877) gets merged.