### PR TITLE
Reload animation of F5

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -95,7 +95,7 @@ export default function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
   const [isInitialized, setIsInitialized] = useState(false);
-  const [isEthABlocked, setIsEthABlocked] = useState(false)
+  const [isEthABlocked, setIsEthABlocked] = useState(false);
   useEffect(() => {
     if(isInitialized) {
       return;
@@ -125,7 +125,7 @@ export default function Home() {
                 >
               </div>
           </div>
-          <img src={logo} alt="Neutralinojs" />
+          <img src={`${logo}?${new Date().getTime()}`} alt="Neutralinojs" />
           <div className={styles.buttons}>
             <Link
               className={clsx(

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -125,7 +125,7 @@ export default function Home() {
                 >
               </div>
           </div>
-          <img src={`${logo}?${new Date().getTime()}`} alt="Neutralinojs" />
+          <img src={`${logo}?v=${new Date().getTime()}`} alt="Neutralinojs" />
           <div className={styles.buttons}>
             <Link
               className={clsx(


### PR DESCRIPTION
- On some browsers, because pages gets cached, the animation doesn't reload with F5 (though it reloads with `ctrl+shift+r`). Note that the previous implementation worked fine locally but not on the webpage. The current implementation works fine locally and needs a test on webpage.