### PR TITLE
Improve the Windows part of the framework developer guide

### DIFF
--- a/docs/contributing/framework-developer-guide.mdx
+++ b/docs/contributing/framework-developer-guide.mdx
@@ -60,8 +60,11 @@ sudo pacman -S \
 
 #### Windows
 
-Install the latest Visual Studio IDE. Neutralinojs compilation on Windows will use
-MSVC (aka `cl.exe`) C++ compiler.
+Install the latest Visual Studio IDE with Windows SDK:
+
+While installing it in the Visual Studio Installer, go to tab Workloads, section "Desktop & Mobile" and select "Desktop development with C++". On the right in "Installation details" > "Desktop development with C++" > "Optional", make sure "Windows 10 SDK" is checked.
+
+The Neutralinojs compilation will use the MSVC C++ compiler (aka `cl.exe`).
 
 #### macOS
 

--- a/docs/contributing/framework-developer-guide.mdx
+++ b/docs/contributing/framework-developer-guide.mdx
@@ -60,11 +60,11 @@ sudo pacman -S \
 
 #### Windows
 
-Install the latest Visual Studio IDE with Windows SDK:
+Install the latest Visual Studio IDE with Windows SDK. The Neutralinojs compilation process will use the MSVC C++ compiler (aka `cl.exe`).
 
-While installing it in the Visual Studio Installer, go to tab Workloads, section "Desktop & Mobile" and select "Desktop development with C++". On the right in "Installation details" > "Desktop development with C++" > "Optional", make sure "Windows 10 SDK" is checked.
-
-The Neutralinojs compilation will use the MSVC C++ compiler (aka `cl.exe`).
+:::info
+How to activate Windows 10 SDK: While installing it in the Visual Studio Installer, go to tab Workloads, section "Desktop & Mobile" and select "Desktop development with C++". On the right in "Installation details" > "Desktop development with C++" > "Optional", make sure "Windows 10 SDK" is checked.
+:::
 
 #### macOS
 


### PR DESCRIPTION
Added the requirement of "Windows SDK" to the Visual Studio IDE installation in the Windows part.