### PR TITLE
Changed type for neutralino.config.json docs

### DIFF
--- a/docs/configuration/neutralino.config.json.md
+++ b/docs/configuration/neutralino.config.json.md
@@ -158,7 +158,7 @@ inside entries.
 }
 ```
 
-### `globalVariables: object[]`
+### `globalVariables: object`
 A key-value-based JavaScript object of custom [global variables](../api/global-variables#custom-global-variables).
 
 ### `logging.enabled: boolean`


### PR DESCRIPTION
`globalVariables` is actually an object. Haven't found an example if it works with arrays, but correct me if im wrong