### PR TITLE
Fixed getSpawnedProcesses code example typo

### DIFF
--- a/docs/api/os.md
+++ b/docs/api/os.md
@@ -111,7 +111,7 @@ An array of `SpawnedProcess` objects.
 await Neutralino.os.spawnProcess('ping neutralino.js.org');
 await Neutralino.os.spawnProcess('ping codezri.org');
 
-let processes = await Neutralino.getSpawnedProcesses();
+let processes = await Neutralino.os.getSpawnedProcesses();
 console.log(processes);
 ```
 


### PR DESCRIPTION
Changed it from `let processes = await Neutralino.getSpawnedProcesses();` to `let processes = await Neutralino.os.getSpawnedProcesses();` (the `os.` was missing)