### PR TITLE
Update api/updater.md with a note about required nativeAllowList strings

### DIFF
--- a/docs/api/updater.md
+++ b/docs/api/updater.md
@@ -10,7 +10,7 @@ Learn more about extensions with [this guide](../how-to/auto-updater).
 
 
 :::note
-For this API to work, you will need to add `"filesystem.*"` and `"updater.*"` to the [`nativeAllowList` field](https://neutralino.js.org/docs/configuration/neutralino.config.json#nativeallowlist-string) of your `neutralino.config.json`.
+For this API to work, you should add `"filesystem.writeBinaryFile"` to the [`nativeAllowList` field](../configuration/neutralino.config.json#nativeallowlist-string) of your `neutralino.config.json` file.
 :::
 
 

--- a/docs/api/updater.md
+++ b/docs/api/updater.md
@@ -9,6 +9,11 @@ third-party update services, operating system level services, or other binaries/
 Learn more about extensions with [this guide](../how-to/auto-updater).
 
 
+:::note
+For this API to work, you will need to add `"filesystem.*"` and `"updater.*"` to the [`nativeAllowList` field](https://neutralino.js.org/docs/configuration/neutralino.config.json#nativeallowlist-string) of your `neutralino.config.json`.
+:::
+
+
 ## updater.checkForUpdates(url)
 Checks latest updates from the given URL. The URL should return a valid Neutralinojs update manifest with
 `Content-Type: application/json` header. Throws `NE_UP_CUPDMER` for invalid manifests and `NE_UP_CUPDERR`


### PR DESCRIPTION
`updater.install` fails with `NE_UP_UPDINER` if `filesystem` API is not allowed. This PR adds a small note that you need to allow `filesystem` and `updater` in one's `neutralino.config.json`.