### PR TITLE
Update neutralino config to include "chrome" default mode option

### DIFF
--- a/docs/configuration/neutralino.config.json.md
+++ b/docs/configuration/neutralino.config.json.md
@@ -33,7 +33,7 @@ Unique string to identify your application. Eg: `js.neutralino.sample`
 Application version. Eg: `2.4.22`
 
 ### `defaultMode: string`
-Mode of the application. Accepted values are `window`, `browser`, and `cloud`.
+Mode of the application. Accepted values are `window`, `browser`, `cloud`, and `chrome`.
 
 ## General
 You can override the following configuration values from different modes. For example, you can use a specific


### PR DESCRIPTION
Was going through the docs and getting started with my first project when i noticed the `chrome` option wasn't listed as one of the available options for the `defaultMode` key in the config page!