### PR TITLE
Adding neutralinojs-menubar to the resources section for the website

### DIFF
--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -62,6 +62,11 @@ const libraries = [
         description: 'A cURL wrapper for Neutralinojs',
         githubLink: 'https://github.com/hschneider/neutralino-curl',
     },
+    {
+        title: 'neutralinojs-menubar',
+        description: 'A native-looking menubar for Neutralinojs',
+        githubLink: 'https://github.com/scanline/neutralinojs-menubar',
+    },  
 ];
 
 const buildTools = [

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -49,6 +49,11 @@ const extensions = [
         description: 'A low-code Python extension for Neutralinojs',
         githubLink: 'https://github.com/hschneider/neutralino-ext-python',
     },
+    {
+        title: 'neutralinojs-ext-vibrancy',
+        description: 'A C++ vibrancy effect extension for Neutralinojs',
+        githubLink: 'https://github.com/scanline/neutralinojs-ext-vibrancy',
+    },    
 ];
 
 const libraries = [


### PR DESCRIPTION
Though the title says it all, I've linked to:
[https://github.com/scanline/neutralinojs-menubar](https://github.com/scanline/neutralinojs-menubar)

in the resources section and also [https://github.com/scanline/neutralinojs-ext-vibrancy](https://github.com/scanline/neutralinojs-ext-vibrancy)