### PR TITLE
Remove reference to libwebkit2gtk-4.x-dev from docs

### DIFF
--- a/docs/contributing/framework-developer-guide.mdx
+++ b/docs/contributing/framework-developer-guide.mdx
@@ -37,12 +37,6 @@ Install GTK, WebKit, other libraries with the following command.
 sudo apt install libgtk-3-dev
 ```
 
-```bash
-sudo apt install libwebkit2gtk-4.0-37 libwebkit2gtk-4.0-dev
-# --- or ---
-sudo apt install libwebkit2gtk-4.1-0 libwebkit2gtk-4.1-dev
-```
-
 ##### Fedora
 
 ```bash
@@ -52,8 +46,6 @@ sudo dnf install \
     webkit2gtk3.x86_64 \
     webkit2gtk3-devel.x86_64 \
     libgtk-3-dev \
-    libwebkit2gtk-4.0-37 \
-    libwebkit2gtk-4.0-dev \
     libglib2.0-dev \
     libxrandr-dev
 ```


### PR DESCRIPTION
### Description:
This PR updates the docs to remove fixed webkitgtk version, as it loads the existing version dynamically.