### PR TITLE
Added info block for UWP context localhost issue above neu -v

### DIFF
--- a/docs/cli/neu-cli.md
+++ b/docs/cli/neu-cli.md
@@ -79,6 +79,13 @@ incomplete features. Therefore, avoid using `nightly` versions in your productio
 to try out latest features, but use a stable version for production apps.
 :::
 
+:::info
+If you are on Windows, you might get a blank white screen when running Neutralinojs applications. This issue occurs because accessing localhost from a UWP context is disabled by default. To fix this, run the following command with administrative privileges in the command prompt:
+
+```powershell
+CheckNetIsolation.exe LoopbackExempt -a -n="Microsoft.Win32WebViewHost_cw5n1h2txyewy"
+:::
+
 ### `neu version`
 Prints all version information. If this command is executed from a Neutralinojs application directory,
 you will see project-specific version details. Otherwise, you will see global version details.


### PR DESCRIPTION
This PR adds an info block in the neu-cli.mdx file above the neu -v section. The block explains how to fix a blank white screen issue when running Neutralinojs on Windows due to localhost access restrictions in a UWP context. The fix includes the CheckNetIsolation.exe command.