### PR TITLE
Added documentation for HTML clipboard API support

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -28,6 +28,17 @@ Writes text into the system clipboard. 
 await Neutralino.clipboard.writeText('Test value');
 ```
 
+## clipboard.writeHTML(html)
+Writes HTML into the system clipboard.
+
+### Parameters
+
+- `html` String: HTML to store into the system clipboard.
+
+```js
+await Neutralino.clipboard.writeHTML('<p style="color:red;">Formatted Text</p>');
+```
+
 ## clipboard.writeImage(image)
 Writes image into the system clipboard. 
 
@@ -60,6 +71,18 @@ Stored text from the system clipboard.
 ```js
 let clipboardText = await Neutralino.clipboard.readText();
 console.log(`Text: ${clipboardText}`);
+```
+
+## clipboard.readHTML()
+Reads and returns HTML from system clipboard. 
+
+### Return String (awaited):
+Stored HTML from the system clipboard.
+
+
+```js
+let clipboardHTML = await Neutralino.clipboard.readHTML();
+console.log(`HTML: ${clipboardHTML}`);
 ```
 
 ## clipboard.readImage()


### PR DESCRIPTION
## Overview
Neutralinojs now supports HTML clipboard operations, enabling rich text and formatted content handling across different platforms.

## Changes Made
- Added documentation for `writeHTML()` clipboard API method
- Added documentation for `readHTML()` clipboard API method