### PR TITLE
Add security configuration section to API overview

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -26,59 +26,25 @@ environment variable.
 Once the Neutralinojs server finishes the task, it sends a WebSocket message with the value of the environment variable.
 Finally, the client library resolves a promise with the results received from the server.
 
-The client library maintains a task pool to map the server messages to the matching request via an UUID string.
+The client library maintains a task pool to map the server messages to the matching request via a UUID string.
 
 Neutralinojs offers many native operations for you by using this communication mechanism for all [modes](../configuration/modes).
 
-## Security: Configuring Allow/Block Lists  
-
-Neutralino.js restricts access to native APIs by default for security reasons. Developers must explicitly allow or block APIs using the `nativeAllowList` and `nativeBlockList` properties in `neutralino.config.json`.  
-
-### **How to Configure `nativeAllowList`**  
-Modify your `neutralino.config.json` file to specify which APIs your app can use:  
+Developers can configure native API calling permissions using [`nativeAllowList`](../configuration/neutralino.config.json.md/#nativeallowlist-string) and [`nativeBlockList`](../configuration/neutralino.config.json.md/#nativeblocklist-string) properties in the application configuration file:
 
 ```json
 {
-  "modes": {
-    "window": {
-      "enable": true
-    }
-  },
   "nativeAllowList": [
-    "os.*",
-    "filesystem.readFile",
-    "filesystem.writeFile"
-  ]
-}
-```
-Explanation of Allowed APIs
-
-`os.*` → Grants access to all OS-related APIs.
-
-`filesystem.readFile` → Allows reading files.
-
-`filesystem.writeFile` → Allows writing files.
-
-APIs not listed in the allow list will be blocked by default.
-
-### **How to Configure `nativeAllowList`**
-In addition to allowing APIs, you can explicitly block specific APIs using nativeBlockList. APIs listed here will be denied access, even if they are in nativeAllowList.
-
-```json
-{
+    "app.*",
+    "window.*",
+    "os.execCommand"
+  ],
   "nativeBlockList": [
-    "os.execCommand",
-    "filesystem.deleteFile"
+    "filesystem.remove",
+    "extensions.*"
   ]
 }
 ```
-Explanation of Blocked APIs
-
-`os.execCommand` → Prevents executing system commands.
-
-`filesystem.deleteFile` → Blocks file deletion operations.
-
-Priority: APIs in nativeBlockList take precedence over nativeAllowList. If an API is in both lists, it will be blocked.
 
 ## Native API namespaces
 
@@ -96,3 +62,4 @@ Priority: APIs in nativeBlockList take precedence over nativeAllowList. If an AP
 - [Neutralino.updater](../api/updater.md)
 - [Neutralino.window](../api/window.md)
 - [Neutralino.resources](../api/resources.md)
+- [Neutralino.server](../api/server.md)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -30,6 +30,33 @@ The client library maintains a task pool to map the server messages to the match
 
 Neutralinojs offers many native operations for you by using this communication mechanism for all [modes](../configuration/modes).
 
+## Security: Configuring Allow/Block Lists  
+
+Neutralino.js restricts access to native APIs by default for security reasons. Developers must explicitly allow APIs using the `nativeAllowList` property in `neutralino.config.json`. This ensures that only required APIs are accessible, reducing security risks.  
+
+### **How to Configure `nativeAllowList`**  
+Modify your `neutralino.config.json` file to specify which APIs your app can use:  
+
+```json
+{
+  "modes": {
+    "window": {
+      "enable": true
+    }
+  },
+  "nativeAllowList": [
+    "os.*",
+    "filesystem.readFile",
+    "filesystem.writeFile"
+  ]
+}
+
+Explanation of Allowed APIs
+"os.*" → Grants access to all OS-related APIs.
+"filesystem.readFile" → Allows reading files.
+"filesystem.writeFile" → Allows writing files.
+APIs not listed in the allow list will be blocked by default.
+
 ## Native API namespaces
 
 - [Neutralino.app](../api/app.md)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -54,7 +54,9 @@ Modify your `neutralino.config.json` file to specify which APIs your app can use
 Explanation of Allowed APIs
 
 `os.*` → Grants access to all OS-related APIs.
+
 `filesystem.readFile` → Allows reading files.
+
 `filesystem.writeFile` → Allows writing files.
 
 APIs not listed in the allow list will be blocked by default.
@@ -73,6 +75,7 @@ In addition to allowing APIs, you can explicitly block specific APIs using nativ
 Explanation of Blocked APIs
 
 `os.execCommand` → Prevents executing system commands.
+
 `filesystem.deleteFile` → Blocks file deletion operations.
 
 Priority: APIs in nativeBlockList take precedence over nativeAllowList. If an API is in both lists, it will be blocked.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -32,7 +32,7 @@ Neutralinojs offers many native operations for you by using this communication m
 
 ## Security: Configuring Allow/Block Lists  
 
-Neutralino.js restricts access to native APIs by default for security reasons. Developers must explicitly allow APIs using the `nativeAllowList` property in `neutralino.config.json`. This ensures that only required APIs are accessible, reducing security risks.  
+Neutralino.js restricts access to native APIs by default for security reasons. Developers must explicitly allow or block APIs using the `nativeAllowList` and `nativeBlockList` properties in `neutralino.config.json`.  
 
 ### **How to Configure `nativeAllowList`**  
 Modify your `neutralino.config.json` file to specify which APIs your app can use:  
@@ -50,12 +50,32 @@ Modify your `neutralino.config.json` file to specify which APIs your app can use
     "filesystem.writeFile"
   ]
 }
-
+```
 Explanation of Allowed APIs
+
 "os.*" → Grants access to all OS-related APIs.
 "filesystem.readFile" → Allows reading files.
 "filesystem.writeFile" → Allows writing files.
+
 APIs not listed in the allow list will be blocked by default.
+
+### **How to Configure `nativeAllowList`**
+In addition to allowing APIs, you can explicitly block specific APIs using nativeBlockList. APIs listed here will be denied access, even if they are in nativeAllowList.
+
+```json
+{
+  "nativeBlockList": [
+    "os.execCommand",
+    "filesystem.deleteFile"
+  ]
+}
+```
+Explanation of Blocked APIs
+
+"os.execCommand" → Prevents executing system commands.
+"filesystem.deleteFile" → Blocks file deletion operations.
+
+Priority: APIs in nativeBlockList take precedence over nativeAllowList. If an API is in both lists, it will be blocked.
 
 ## Native API namespaces
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -72,8 +72,8 @@ In addition to allowing APIs, you can explicitly block specific APIs using nativ
 ```
 Explanation of Blocked APIs
 
-"os.execCommand" → Prevents executing system commands.
-"filesystem.deleteFile" → Blocks file deletion operations.
+`os.execCommand` → Prevents executing system commands.
+`filesystem.deleteFile` → Blocks file deletion operations.
 
 Priority: APIs in nativeBlockList take precedence over nativeAllowList. If an API is in both lists, it will be blocked.
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -53,9 +53,9 @@ Modify your `neutralino.config.json` file to specify which APIs your app can use
 ```
 Explanation of Allowed APIs
 
-"os.*" → Grants access to all OS-related APIs.
-"filesystem.readFile" → Allows reading files.
-"filesystem.writeFile" → Allows writing files.
+`os.*` → Grants access to all OS-related APIs.
+`filesystem.readFile` → Allows reading files.
+`filesystem.writeFile` → Allows writing files.
 
 APIs not listed in the allow list will be blocked by default.
 

--- a/docs/getting-started/your-first-neutralinojs-app.mdx
+++ b/docs/getting-started/your-first-neutralinojs-app.mdx
@@ -156,6 +156,19 @@ with the following `nativeAllowList` permission setup:
 We don't need to update anything in the permission setup since it already allows `os.getEnv` native function
 calls.
 
+:::info
+**Note for Windows Users:**  
+If you encounter the following error when running `neu` commands: 
+
+File C:\Users\KRISH\AppData\Roaming\npm\neu.ps1 cannot be loaded because running scripts is disabled on this system.
+For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.
+
+
+This issue occurs due to PowerShell's script execution policy. To resolve it, open PowerShell as an administrator and run:
+
+`Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`
+:::
+
 ## Step 3: Running your application
 
 As mentioned above, you can use the `run` command to start your application.

--- a/docs/getting-started/your-first-neutralinojs-app.mdx
+++ b/docs/getting-started/your-first-neutralinojs-app.mdx
@@ -156,19 +156,6 @@ with the following `nativeAllowList` permission setup:
 We don't need to update anything in the permission setup since it already allows `os.getEnv` native function
 calls.
 
-:::info
-**Note for Windows Users:**  
-If you encounter the following error when running `neu` commands: 
-
-File C:\Users\KRISH\AppData\Roaming\npm\neu.ps1 cannot be loaded because running scripts is disabled on this system.
-For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.
-
-
-This issue occurs due to PowerShell's script execution policy. To resolve it, open PowerShell as an administrator and run:
-
-`Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`
-:::
-
 ## Step 3: Running your application
 
 As mentioned above, you can use the `run` command to start your application.


### PR DESCRIPTION
Added a new section to the API Overview explaining how to configure nativeAllowList in neutralino.config.json. This helps developers understand how to enable specific native APIs securely.