### PR TITLE
Added docs for timestamp field in watchFile event

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -25,7 +25,7 @@ by the Neutralinojs server based on native state changes.
 | `extensionReady`            | Occurs when an extension is ready to communicate with the app.    | `all` | Extension identifier
 | `spawnedProcess`            | Occurs then there is an update in the spawned process.  | `all` | [`SpawnedProcess`](os.md#spawnedprocess) with `action` (`stdOut`, `stdErr`, and `exit`) and `data` (STDOUT, STDERR or exit code)
 | `openedFile`                | Occurs for each read action and whenever stream cursor reaches EOF. | `all` | File stream identifier with `action` (`data`, `dataBinary`, and `end`) and `data` (stream block content)
-| `watchFile`                 | Occurs for each filesystem change events based on watchers. | `all` | File watcher identifier with `action` (`add`, `delete`, `modified`, and `moved`), `dir`, and `filename`
+| `watchFile`                 | Occurs for each filesystem change events based on watchers. | `all` | File watcher identifier with `action` (`add`, `delete`, `modified`, and `moved`), `dir`, `filename` and `timestamp` in ISO 8601 format
 ## events.on(eventName, handler)
 Registers a new event handler. 
 


### PR DESCRIPTION
Modified ``Event types`` table in ``events.md`` to include ``timestamp`` field in the ``watchFile`` event.