### PR TITLE
Added plugins section on resource page

### DIFF
--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -87,6 +87,19 @@ const buildTools = [
     },
 ];
 
+const plugins = [
+    {
+        title: 'Neutralinojs CLI - Plugin-Explorer',
+        description: 'This plugin allows users to search for available plugins, get detailed information about specific plugins, and list all available plugins',
+        githubLink: 'https://github.com/rahulptl165/Plugin-Explorer',
+    },
+    {
+        title: 'Neutralinojs CLI - Templates Plugin',
+        description: 'Adds functionality to manage and reuse locally saved templates in Neutralinojs CLI, eliminating the need to repeatedly download or clone remote templates.',
+        githubLink: 'https://github.com/rahulptl165/neutralinojs-templates',
+    }
+];
+
 function ResourceSection({title, resources}) {
     return (
         <section className={styles.features}>
@@ -138,6 +151,7 @@ export default function NeutralinoTools() {
                 <ResourceSection title="Extensions" resources={extensions}/>
                 <ResourceSection title="Libraries" resources={libraries}/>
                 <ResourceSection title="Build tools" resources={buildTools}/>
+                <ResourceSection title="Plugins" resources={plugins}/>
             </main>
         </Layout>
     );

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -87,15 +87,15 @@ const buildTools = [
     },
 ];
 
-const plugins = [
+const cliPlugins = [
     {
-        title: 'Neutralinojs CLI - Plugin-Explorer',
-        description: 'This plugin allows users to search for available plugins, get detailed information about specific plugins, and list all available plugins',
+        title: 'rahulptl165/plugin-explorer',
+        description: 'Search for available neu CLI plugins, get detailed information about specific plugins, and list all available plugins',
         githubLink: 'https://github.com/rahulptl165/Plugin-Explorer',
     },
     {
-        title: 'Neutralinojs CLI - Templates Plugin',
-        description: 'Adds functionality to manage and reuse locally saved templates in Neutralinojs CLI, eliminating the need to repeatedly download or clone remote templates.',
+        title: 'neutralinojs-templates',
+        description: 'Adds functionality to manage and reuse locally saved neu CLI templates',
         githubLink: 'https://github.com/rahulptl165/neutralinojs-templates',
     }
 ];
@@ -151,7 +151,7 @@ export default function NeutralinoTools() {
                 <ResourceSection title="Extensions" resources={extensions}/>
                 <ResourceSection title="Libraries" resources={libraries}/>
                 <ResourceSection title="Build tools" resources={buildTools}/>
-                <ResourceSection title="Plugins" resources={plugins}/>
+                <ResourceSection title="CLI plugins" resources={cliPlugins}/>
             </main>
         </Layout>
     );


### PR DESCRIPTION
## Added plugin section on resources page. 

### changes made 
* created a plugins array of object to store name, description, and git repository and then displayed this details on the resources page.

### screenshot after changes made:
![Screenshot (78)](https://github.com/user-attachments/assets/d3accb83-bd89-42b2-86e9-af2eb781efe0)
