### PR TITLE
Add interactive Neutralinojs code playground with sample code

### DIFF
--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -1,0 +1,13 @@
+---
+id: try-it
+title: Try Neutralinojs in Your Browser
+sidebar_label: Try It
+---
+
+import Playground from '../src/components/Playground';
+
+# Try Neutralinojs
+
+Experiment with Neutralinojs APIs below—no setup required!
+
+<Playground />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,6 +25,9 @@ module.exports = {
         src: 'img/logo.png',
       },
       items: [
+      { to: '/docs/try-it', label: 'Try It', position: 'left' },
+    ],
+      items: [
         {
           to: 'docs/',
           activeBasePath: 'docs',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@docusaurus/plugin-google-gtag": "^3.3.2",
     "@docusaurus/preset-classic": "^3.3.2",
     "@mdx-js/react": "^3.0.0",
+    "@monaco-editor/react": "4.4.6",
     "clsx": "^1.1.1",
     "docusaurus-lunr-search": "^3.3.2",
     "react": "^18.2.0",

--- a/sidebars.js
+++ b/sidebars.js
@@ -7,6 +7,7 @@ module.exports = {
         'getting-started/introduction',
         'getting-started/your-first-neutralinojs-app',
         'getting-started/using-frontend-libraries',
+        'try-it',
       ],
     },
     {

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import Editor from '@monaco-editor/react';
+
+const Playground = () => {
+  const [code, setCode] = useState(
+    `// Sample Neutralinojs code\nNeutralino.init();\nNeutralino.window.setTitle("Hello from the Playground!");\nNeutralino.os.showMessageBox("Welcome", "This is a mock message box!");\nNeutralino.filesystem.readFile("sample.txt", (data) => {\n  console.log("File content:", data);\n}, () => {\n  console.log("Failed to read file");\n});`
+  );
+  const [outputMessages, setOutputMessages] = useState([]);
+
+  const addMessage = (message, type = 'success') => {
+    setOutputMessages((prev) => [...prev, { message, type }]);
+  };
+
+  const runCode = () => {
+    setOutputMessages([]);
+    try {
+      const Neutralino = {
+        init: () => addMessage('Initialized Neutralino', 'success'),
+        window: {
+          setTitle: (title) => addMessage(`Window title set to: ${title}`, 'success'),
+        },
+        os: {
+          showMessageBox: (title, content) =>
+            addMessage(`MessageBox: ${title} - ${content}`, 'success'),
+        },
+        filesystem: {
+          readFile: (path, successCallback, errorCallback) => {
+            if (path === 'sample.txt') {
+              successCallback('This is a mock file content!');
+            } else {
+              errorCallback();
+            }
+          },
+        },
+      };
+      const console = {
+        log: (...args) => addMessage(`Console: ${args.join(' ')}`, 'info'),
+      };
+      // eslint-disable-next-line no-eval
+      eval(code);
+    } catch (e) {
+      addMessage(`Error: ${e.message}`, 'error');
+    }
+  };
+
+  return (
+    <div className="playground-container">
+      <div className="playground-content">
+        <div className="playground-editor">
+          <h3 className="playground-editor-header">Code Editor</h3>
+          <Editor
+            height="500px"
+            language="javascript"
+            value={code}
+            onChange={(value) => setCode(value)}
+            theme="vs-dark"
+            loading={<div>Loading editor...</div>}
+          />
+          <button className="playground-run-button" onClick={runCode}>
+            Run Code
+          </button>
+        </div>
+        <div className="playground-output-container">
+          <h3 className="playground-output-header">Output</h3>
+          <div className="playground-output">
+            {outputMessages.length === 0 ? (
+              <span className="playground-output-placeholder">Run your code to see the output...</span>
+            ) : (
+              outputMessages.map((msg, index) => (
+                <div key={index} className={`playground-output-message playground-output-${msg.type}`}>
+                  {msg.message}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Playground;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,3 +23,153 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+/* Playground Container */
+.playground-container {
+  margin: 20px 0;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+html[data-theme='dark'] .playground-container {
+  background-color: #1a1a1a;
+  border-color: #444;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Content Section */
+.playground-content {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+/* Editor Section */
+.playground-editor {
+  flex: 2;
+  min-width: 400px;
+  display: flex;
+  flex-direction: column;
+}
+
+.playground-editor-header {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+html[data-theme='dark'] .playground-editor-header {
+  color: #ddd;
+}
+
+/* Output Container */
+.playground-output-container {
+  flex: 1;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+}
+
+.playground-output-header {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+html[data-theme='dark'] .playground-output-header {
+  color: #ddd;
+}
+
+/* Output Section */
+.playground-output {
+  background-color: #f5f5f5;
+  padding: 16px;
+  border-radius: 4px;
+  min-height: 500px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+  color: #333;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-grow: 1;
+}
+
+html[data-theme='dark'] .playground-output {
+  background-color: #2a2a2a;
+  color: #ddd;
+}
+
+/* Placeholder Text */
+.playground-output-placeholder {
+  color: #888;
+  font-style: italic;
+}
+
+html[data-theme='dark'] .playground-output-placeholder {
+  color: #aaa;
+}
+
+/* Output Messages */
+.playground-output-message {
+  margin: 0;
+  padding: 4px 0;
+}
+
+.playground-output-success {
+  color: #28a745;
+}
+
+html[data-theme='dark'] .playground-output-success {
+  color: #34c759;
+}
+
+.playground-output-error {
+  color: #dc3545;
+}
+
+html[data-theme='dark'] .playground-output-error {
+  color: #ff5555;
+}
+
+.playground-output-info {
+  color: #17a2b8;
+}
+
+html[data-theme='dark'] .playground-output-info {
+  color: #4dc0b5;
+}
+
+/* Run Button */
+.playground-run-button {
+  margin-top: 10px;
+  padding: 6px 12px;
+  background-color: #f9a826;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+  width: auto;
+  display: inline-block;
+}
+
+.playground-run-button:hover {
+  background-color: #e69100;
+}
+
+html[data-theme='dark'] .playground-run-button {
+  background-color: #f9a826;
+}
+
+html[data-theme='dark'] .playground-run-button:hover {
+  background-color: #e69100;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,6 +1809,21 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
+"@monaco-editor/loader@^1.3.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.5.0.tgz#dcdbc7fe7e905690fb449bed1c251769f325c55d"
+  integrity sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.4.6.tgz#8ae500b0edf85276d860ed702e7056c316548218"
+  integrity sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==
+  dependencies:
+    "@monaco-editor/loader" "^1.3.2"
+    prop-types "^15.7.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -7909,6 +7924,11 @@ srcset@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-4.0.0.tgz#336816b665b14cd013ba545b6fe62357f86e65f4"
   integrity sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
close #389
This PR adds a browser-based code playground to the Neutralinojs website under `/docs/try-it`. Features:
- Monaco Editor for writing code.
- Mock Neutralinojs APIs (init, window.setTitle, os.showMessageBox, filesystem.readFile).
- Sample code to test the APIs.
- Polished UI with dark mode support, proper alignment, compact Run Code button, and increased editor size.
- Files added: `docs/try-it.mdx`, `src/components/Playground.js`, `src/css/custom.css`.
- Dependencies: `@monaco-editor/react@4.4.6`.

![image](https://github.com/user-attachments/assets/f1b94138-c33d-4a4c-8554-6f718305ccf1)
