### PR TITLE
Add vite-react-ts template

### DIFF
--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -31,6 +31,11 @@ const templates = [
         description: 'A template for bundling binaries into installers using GitHub actions',
         githubLink: 'https://github.com/TolinSimpson/neutralinojs-build-automation-template',
     },
+    {
+        title: 'neutralinojs-vite-react-ts',
+        description: 'A Vite + React + TypeScript Template for building Neutralinojs apps',
+        githubLink: 'https://github.com/Cloudwerk/neutralinojs-vite-react-ts',
+    },
 ];
 
 const extensions = [


### PR DESCRIPTION
We've made a [template](https://github.com/Cloudwerk/neutralinojs-vite-react-ts) for using Vite in combination with React and Typescript for building Neutralino Apps.
Consider adding it to the homepage :)