### PR TITLE
Documentation about Portable Builds

### DIFF
--- a/docs/cli/neu-cli.md
+++ b/docs/cli/neu-cli.md
@@ -45,8 +45,13 @@ The default value is [`neutralinojs/neutralinojs-minimal`](https://github.com/ne
 This command will create the `dist` folder. Thereafter, it will produce the binaries for all supported
 platforms and `resources.neu` resource file from your application resources.
 
+:::info
+Building with the `--embed-resources` options will not generate the `resources.neu` or a common build. With this flag, every executable inside the `dist` folder will be a `Single-File` version.
+:::
+
 #### Options
 - `--release`: Creates a portable ZIP file of the application bundle.
+- `--embed-resources`: Creates a real `Single-File` executable for each platform without a `resources.neu` file.
 - `--copy-storage`: Copies the current snapshot of the Neutralinojs storage to the application bundle.
 - `--macos-bundle`: Creates a minimal MacOS app bundle by adding the `.app` extension.
 - `--config-file=<path>`: Uses a custom app configuration file only for the packaging process.

--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -30,6 +30,7 @@ title: Committers
 - [Rushil Choudhary](https://github.com/rushil-118)
 - [Alok](https://github.com/Oshlok)
 - [Rahul Kumar](https://github.com/rahulptl165)
+- [Ismael Cortés](https://github.com/IsmaCortGtz)
 
 See all contributors [here](https://github.com/neutralinojs/neutralinojs/graphs/contributors)
 


### PR DESCRIPTION
Hi! This PR creates the documentation about the `--embed-resources` flag on the `neu build` CLI command.

Additionally I added myself to the [`Committers`](https://neutralino.js.org/docs/contributing/committers) section.

I also opened a PR ([#302](https://github.com/neutralinojs/neutralinojs-cli/pull/302)) in [`neutralinojs/neutralinojs-cli`](https://github.com/neutralinojs/neutralinojs-cli) to add this feature; all the information about the new flag will be there.