### PR TITLE
Change return type of getPosition to Object

### DIFF
--- a/docs/api/window.md
+++ b/docs/api/window.md
@@ -274,7 +274,7 @@ console.log(sizeInfo);
 ## window.getPosition()
 Returns window position coordinates.
 
-### Return Boolean (awaited):
+### Return Object (awaited):
 
 - `x` Number: Horizontal coordinate of the left edge of the window.
 - `y` Number: Vertical coordinate of the top edge of the window.


### PR DESCRIPTION
Updated return type for window.getPosition() to Object.