### PR TITLE
docs: fix incorrect server.unmount example

### DIFF
--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -27,7 +27,8 @@ Deactivates a mount configuration. Throws `NE_SR_NOMTPTH` if the provided path i
 - `path` String: Resource path.
 
 ```js
-await Neutralino.server.mount('/app-res', NL_PATH + '/app-res');
+await Neutralino.server.unmount('/app-res');
+
 ```
 
 ## server.getMounts()


### PR DESCRIPTION
### Fix incorrect `server.unmount` example

The documentation showed `server.mount` under the `server.unmount` section.
This PR corrects the example to use `Neutralino.server.unmount`.

Fixes #404
