### PR TITLE
Fix duplicated word "the the" in Privacy Policy page

### DIFF
--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -12,11 +12,11 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Privacy Policy`}
-      description="Privacy policy of the the Neutralinojs website and documentation">
+      description="Privacy policy of the Neutralinojs website and documentation">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">Privacy Policy</h1>
-          <p className="hero__subtitle">Privacy policy of the the Neutralinojs website and documentation</p>
+          <p className="hero__subtitle">Privacy policy of the Neutralinojs website and documentation</p>
         </div>
       </header>
       <div className={styles.intro}>


### PR DESCRIPTION
Fixes #1614

Fix duplicated word "the the" in the Privacy Policy page.

This PR removes the duplicated word appearing in the following lines of the code:
- Layout `description`
- Page subtitle

This improves readability and correctness of the page content.

### Before
<img width="1898" height="499" alt="Screenshot (46)" src="https://github.com/user-attachments/assets/956f5bf2-659c-4baa-9d95-83cc99ca8ea2" />
