### PR TITLE
Fix typos in privacy policy subtitle

### DIFF
--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -12,11 +12,11 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Privacy Policy`}
-      description="Privacy policy of the the Neutralinojs website and documentation">
+      description="Privacy policy of the Neutralinojs website and documentation">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">Privacy Policy</h1>
-          <p className="hero__subtitle">Privacy policy of the the Neutralinojs website and documentation</p>
+          <p className="hero__subtitle">Privacy policy of the Neutralinojs website and documentation</p>
         </div>
       </header>
       <div className={styles.intro}>


### PR DESCRIPTION
There is a duplicated word “the the” on the Privacy Policy page of the Neutralinojs website. The duplication appears in both the meta description and the subtitle, which affects readability and makes the text look unpolished.

This PR removes the extra occurrence of the word “the” to ensure the text reads correctly and maintains a clean presentation.