### PR TITLE
docs: add GUI support warning for WSL users using neu run

### DIFF
--- a/docs/cli/neu-cli.md
+++ b/docs/cli/neu-cli.md
@@ -67,6 +67,9 @@ development evironment at the same time. This option patches the main HTML file 
 client library global variables to expose the native API to the frontend library's development server.
 Learn how to setup this feature from [this](../getting-started/using-frontend-libraries.md) guide.
 
+:::info WSL Users
+If you are using Windows Subsystem for Linux (WSL), ensure you have GUI support (WSLg) enabled. Running `neu run` without a display server configured will result in an application crash or `error code 1`.
+:::
 #### Options
 - `--disable-auto-reload`: Disables the auto-reloading feature.
 - `--arch=<arch>`: Explicitly set the CPU architecture. This option is helpful if you use a 32-bit Node.js process


### PR DESCRIPTION
Replaces #422 with a clean commit history
Summary
Added a quick note in the neu run CLI documentation for Windows WSL users regarding the requirement of GUI support (WSLg).

Reasoning
Saw a couple of newer contributors in Discord (Feb 23) hitting error code 1 when trying to run their first app via WSL because they lacked a display server configuration. Adding this note should help troubleshoot that specific friction point faster.