### PR TITLE
fix : remove duplicated word 'the' in privacy policy page subtitle and meta description

### DIFF
--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -12,11 +12,11 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Privacy Policy`}
-      description="Privacy policy of the the Neutralinojs website and documentation">
+      description="Privacy policy of the Neutralinojs website and documentation">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">Privacy Policy</h1>
-          <p className="hero__subtitle">Privacy policy of the the Neutralinojs website and documentation</p>
+          <p className="hero__subtitle">Privacy policy of the Neutralinojs website and documentation</p>
         </div>
       </header>
       <div className={styles.intro}>


### PR DESCRIPTION
## Summary

This PR fixes a duplicated word ("the the") in the Privacy Policy page of the Neutralinojs website.

The typo appears in:

* the page subtitle
* the HTML meta description

Both occurrences have been corrected to improve readability and accuracy.

## Changes

* Removed the duplicated word `the` from the subtitle.
* Updated the `description` property in the Layout component so the generated meta description is correct.

### Before
<img width="1902" height="840" alt="Screenshot 2026-03-11 013744" src="https://github.com/user-attachments/assets/e43bc90c-b96b-4d94-86d3-e093b10ea2c4" />

### After
<img width="1906" height="757" alt="Screenshot 2026-03-11 004833" src="https://github.com/user-attachments/assets/965b52a2-694d-4d41-a146-c02e1e822f41" />

## Related Issue
Fixes #416 
