### PR TITLE
fix: remove duplicate word 'the' in privacy policy page

### DIFF
--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -12,11 +12,11 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Privacy Policy`}
-      description="Privacy policy of the the Neutralinojs website and documentation">
+      description="Privacy policy of the Neutralinojs website and documentation">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">Privacy Policy</h1>
-          <p className="hero__subtitle">Privacy policy of the the Neutralinojs website and documentation</p>
+          <p className="hero__subtitle">Privacy policy of the Neutralinojs website and documentation</p>
         </div>
       </header>
       <div className={styles.intro}>


### PR DESCRIPTION
Fixes #1614

## Problem
The word "the" was duplicated in two places on the privacy policy page:
- Line 15: meta `description` tag
- Line 19: `hero__subtitle` paragraph

Both showed "Privacy policy of the the Neutralinojs website..." 
which is grammatically incorrect.

## Fix
Removed the extra "the" from both lines in `privacy-policy.js`