### PR TITLE
docs: add M4 and M5 chips to macOS arm64 compatibility

### DIFF
--- a/docs/distribution/overview.md
+++ b/docs/distribution/overview.md
@@ -16,7 +16,7 @@ The `neu build` command generates the following files on any supported operating
 | `myapp-linux_arm64`     | Linux   | `arm64`              | Application binary               |
 | `myapp-mac_x64`         | macOS   | `x86_64`             | Application binary (Intel)       |
 | `myapp-mac_universal`   | macOS   | `x86_64` and `arm64` | Application binary               |
-| `myapp-mac_arm64`       | macOS   | `arm64`              | Application binary (M1/M2/M3)    |
+| `myapp-mac_arm64`       | macOS   | `arm64`              | Application binary (M1/M2/M3/M4/M5)    |
 | `myapp-win_x64`         | Windows | `x86_64`             | Application binary               |
 | `resources.neu`         | all     | `N/A`                | Application resource file        |
 

--- a/docs/distribution/overview.md
+++ b/docs/distribution/overview.md
@@ -16,7 +16,7 @@ The `neu build` command generates the following files on any supported operating
 | `myapp-linux_arm64`     | Linux   | `arm64`              | Application binary               |
 | `myapp-mac_x64`         | macOS   | `x86_64`             | Application binary (Intel)       |
 | `myapp-mac_universal`   | macOS   | `x86_64` and `arm64` | Application binary               |
-| `myapp-mac_arm64`       | macOS   | `arm64`              | Application binary (M1/M2/M3/M4/M5)    |
+| `myapp-mac_arm64`       | macOS   | `arm64`              | Application binary (M1 onward)    |
 | `myapp-win_x64`         | Windows | `x86_64`             | Application binary               |
 | `resources.neu`         | all     | `N/A`                | Application resource file        |
 


### PR DESCRIPTION
## Before:
<img width="862" height="590" alt="image" src="https://github.com/user-attachments/assets/a8443659-4585-48e4-8bbf-55b5bab838fb" />

## After:
<img width="881" height="610" alt="image" src="https://github.com/user-attachments/assets/682aa14f-2880-4eef-b90b-50c478ab50d3" />

