### PR TITLE
fix: remove duplicate 'the' in privacy policy page

### DIFF
--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -12,11 +12,11 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Privacy Policy`}
-      description="Privacy policy of the the Neutralinojs website and documentation">
+      description="Privacy policy of the Neutralinojs website and documentation">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">Privacy Policy</h1>
-          <p className="hero__subtitle">Privacy policy of the the Neutralinojs website and documentation</p>
+          <p className="hero__subtitle">Privacy policy of the Neutralinojs website and documentation</p>
         </div>
       </header>
       <div className={styles.intro}>


### PR DESCRIPTION
Removes the repeated word "the the" in the privacy policy page, both in the HTML meta description and the visible subtitle.

**Before:** `"Privacy policy of the the Neutralinojs website and documentation"`
**After:** `"Privacy policy of the Neutralinojs website and documentation"`

Two-line fix in `src/pages/privacy-policy.js`.

Ref: neutralinojs/neutralinojs#1614