### PR TITLE
docs: fix readFile signature and add Options subsection

### DIFF
--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -89,12 +89,15 @@ await Neutralino.filesystem.appendBinaryFile('./myFile.bin', rawBin);
 await Neutralino.filesystem.appendBinaryFile('./myFile.bin', rawBin);
 ```
 
-## filesystem.readFile(filename)
+## filesystem.readFile(filename, options)
 Reads a text file. Throws `NE_FS_FILRDER` for file read errors.
 
 ### Parameters
 
 - `filename` String: Filename.
+
+### Options
+
 - `pos` Number (optional): File cursor position in bytes.
 - `size` Number (optional): File reader buffer size in bytes.
 


### PR DESCRIPTION
The `readFile` heading was missing the `options` parameter despite 
the code example showing it accepts `pos` and `size` as options.

Changes:
- Updated heading from `readFile(filename)` to `readFile(filename, options)`
- Moved `pos` and `size` into a new Options subsection

This aligns `readFile` with the `readBinaryFile` pattern in the same file.

Closes #<448>
