### PR TITLE
docs: fix wrong parameter name in os.getPath documentation

### DIFF
--- a/docs/api/os.md
+++ b/docs/api/os.md
@@ -303,7 +303,7 @@ await Neutralino.os.setTray(tray);
 Returns known platform-specific folders such as Downloads, Music, Videos, etc.
 
 ### Parameters
-- `title` String: Name of the folder. Accepted values are: `config`, `data`, `cache`, `documents`, `pictures`, `music`, `video`,
+- `name` String: Name of the folder. Accepted values are: `config`, `data`, `cache`, `documents`, `pictures`, `music`, `video`,
             `downloads`, `saveGames1`, `saveGames2`, and `temp`. Throws `NE_OS_INVKNPT` for invalid folder names.
 
 ### Return String (awaited):


### PR DESCRIPTION
## Summary

The `os.getPath` function heading defines the parameter as `name` 
but the Parameters section incorrectly documented it as `title`.

### Change
- `title` String → `name` String in the Parameters section of `os.getPath`

This aligns the parameter name in the docs with the actual function 
signature `os.getPath(name)`.

Closes #<453>