### PR TITLE
docs: fix missing array type annotation for extensions in showOpenDialog Filter

### DIFF
--- a/docs/api/os.md
+++ b/docs/api/os.md
@@ -166,7 +166,7 @@ Shows the file open dialog. You can use this function to obtain paths of existin
 
 #### Filter
 - `name` String: Filter name.
-- `extensions` String: Array of file extensions. Eg: `['jpg', 'png']`
+- `extensions` String[]: Array of file extensions. Eg: `['jpg', 'png']`
 
 ### Return Object (awaited):
 An array of selected entries.


### PR DESCRIPTION
## Summary

The `extensions` field in the `showOpenDialog` Filter object was 
missing the `[]` array type annotation, while the identical field 
in `showSaveDialog` correctly uses `String[]`.

### Change
- `extensions` String → `extensions` String[] in `showOpenDialog` Filter

This prevents developers from mistakenly passing a plain string 
instead of an array when using the `filters` option.

Closes #<454>