### PR TITLE
docs: add embedding resources section to distribution overview

### DIFF
--- a/docs/distribution/overview.md
+++ b/docs/distribution/overview.md
@@ -45,6 +45,25 @@ the resource file. For example, if you need to make an application package for `
 and the `resources.neu` file. The `resources.neu` contains all application resources, so, double click on the binary and check whether
 the resource file is not corrupted.
 
+### Embedding resources into the binary
+
+By default, `neu build` produces two separate files per platform: the application binary and `resources.neu`. Alternatively, you can embed `resources.neu` directly into the binary using the `--embed-resources` flag, producing a **single self-contained executable** with no external resource file dependency.
+
+```bash
+neu build --embed-resources
+```
+
+The following table summarizes the difference:
+
+| Command | Distribution output |
+|---|---|
+| `neu build` | `myapp-linux_x64` + `resources.neu` |
+| `neu build --embed-resources` | `myapp-linux_x64` (resources embedded) |
+
+:::note
+Embedding resources makes it impossible to update application resources without rebuilding the binary. The standard two-file approach is recommended if you plan to patch resources independently between releases.
+:::
+
 ## Creating portable application packages using build scripts 
 
 The [`hschneider/neutralino-build-scripts`](https://github.com/hschneider/neutralino-build-scripts/) community project offers pre-developed build scripts for generating platform-specific application bundles. For example, it generates a standard app structure on GNU/Linux by generating `.desktop` file with app icon by also providing a shell script to install the app. 


### PR DESCRIPTION
### Fixes #467

### Description

Added a new **"Embedding resources into the binary"** subsection under "Selecting files for packaging" to document the `--embed-resources` flag in `neu build`.

### Changes

- Explained that `--embed-resources` injects `resources.neu` into the binary using `postject`, producing a single self-contained executable with no external resource file dependency
- Added a usage example
- Added a comparison table showing the distribution output difference between `neu build` and `neu build --embed-resources`
- Added a note on the trade-off: embedded resources cannot be updated without rebuilding the binary