### PR TITLE
Fix typos in os.md

### DIFF
--- a/docs/api/os.md
+++ b/docs/api/os.md
@@ -161,7 +161,7 @@ Shows the file open dialog. You can use this function to obtain paths of existin
 
 ### Options
 - `filters` Filter[] (optional): An array of Filter objects to filter the files list.
-- `multiSelections` (optional): Enables multi selections.
+- `multiSelections` Boolean (optional): Enables multi selections.
 - `defaultPath` String (optional): Initial path/filename displayed by the dialog.
 
 #### Filter


### PR DESCRIPTION
- Added missing `Boolean` type for `multiSelections` parameter 
  in `os.showOpenDialog()`


## Type
Documentation fix
  
I have submitted the fresh PR here as suggested in pr #425 .
This pr only contains the missing Boolean type fix for multiSelections, as the other issues were already addressed in the main branch.