### PR TITLE
Add Kona Naga Devi to the committers list

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -34,6 +34,7 @@ title: Committers
 - [Prasun Baranwal](https://github.com/prasu-baran)
 - [Anirudh Lakhanpal](https://github.com/SharonIV0x86/)
 - [Sagar](https://github.com/itssagarK)
+- [Kona Naga Devi](https://github.com/nagadevikona20-max)
 
 See all contributors [here](https://github.com/neutralinojs/neutralinojs/graphs/contributors)
 


### PR DESCRIPTION
Adds [Kona Naga Devi](https://github.com/nagadevikona20-max) to the committers list following an invitation from the maintainer on [neutralinojs/neutralinojs#1605](https://github.com/neutralinojs/neutralinojs/pull/1605).