### PR TITLE
docs: defining attributes of cli.frontendLibrary object

### DIFF
--- a/docs/configuration/neutralino.config.json.md
+++ b/docs/configuration/neutralino.config.json.md
@@ -436,6 +436,30 @@ Use `|` character to set multiple regular expressions, as shown below.
 Enables frontend development tools (HMR, etc) for the `neu run` command. Learn more about frontend
 framework integration from [here](../getting-started/using-frontend-libraries.md)
 
+### `cli.frontendLibrary.patchFile: string`
+
+Sets a patch file for the project, when using a frontend library.
+
+### `cli.frontendLibrary.devUrl: string`
+
+The URL of the development server hosted by the frontend library. The site hosted on this URL is displayed when running `neu run`.
+
+### `cli.frontendLibrary.projectPath: string`
+
+Sets the project path of the host project. This path will be used as the current directory while executing frontend-library-related commands.
+
+### `cli.frontendLibrary.initCommand: string`
+
+A command that gets executed after downloading a frontend template with the `neu create` command.
+
+### `cli.frontendLibrary.devCommand: string`
+
+This command will run with the `neu run` command to start the frontend library's development server.
+
+### `cli.frontendLibrary.buildCommand: string`
+
+The `neu build` command will execute this command before generating the app bundle, so you can generate bundled version of frontend code.
+
 ### `cli.hostProject.projectPath: string`
 
 Sets the project path of the host project. This path will be used as the current directory while executing the host-project-related commands.


### PR DESCRIPTION
### Fixes #485 

*The text below is copy and pasted from the original issue.*

### Description

The attributes of [`cli.frontendLibrary`](https://neutralino.js.org/docs/configuration/neutralino.config.json#clifrontendlibrary-object) object are not explicitly covered as a part of the documentation on [`neutralino.config.json`](https://neutralino.js.org/docs/configuration/neutralino.config.json). This includes attributes such as `patchFile`, `devUrl`, `projectPath`, `initCommand`, `devCommand`, `buildCommand`.

It is covered as a part of [`Using Frontend Libraries`](https://neutralino.js.org/docs/getting-started/using-frontend-libraries#enabling-hot-reload-and-configuration). However, the description of these attributes isn't the focus, with some attributes not being explained at all. Some attributes are only included in the example at the bottom of the page, without additional explanation.

Some of these attributes are shared with [`cli.hostProject`](https://neutralino.js.org/docs/configuration/neutralino.config.json#clihostprojectprojectpath-string), meaning you could technically infer the `cli.frontendLibrary` attributes from this. However, there's also no indication on the `neutralino.config.json` page that these objects share any attributes.

### Proposed solution

Append definitions for the attributes of the `cli.frontendLibrary` object, including:
- `cli.frontendLibrary.patchFile`
- `cli.frontendLibrary.devUrl`
- `cli.frontendLibrary.projectPath`
- `cli.frontendLibrary.initCommand`
- `cli.frontendLibrary.devCommand`
- `cli.frontendLibrary.buildCommand`

The attributes `projectPath`, `initCommand`, `devCommand`, and `buildCommand` would have near-identical definitions to the attributes in `cli.hostProject`, for consistency.

These would be added to the [`neutralino.config.json`](https://neutralino.js.org/docs/configuration/neutralino.config.json) documentation, directly underneath the description for `cli.frontendLibrary: object`.

My initial thought for [`cli.frontendLibrary: object`](https://neutralino.js.org/docs/configuration/neutralino.config.json#clifrontendlibrary-object) was to not remove this description, as it redirects to additional guidance in [`Using Frontend Libraries`](https://neutralino.js.org/docs/getting-started/using-frontend-libraries#enabling-hot-reload-and-configuration). However, this would make the documentation format slightly inconsistent between `cli.frontendLibrary` and `cli.hostProject`.